### PR TITLE
Window is opened in Chrome always on top panel instead of popup

### DIFF
--- a/src/background.coffee
+++ b/src/background.coffee
@@ -17,7 +17,7 @@ name = (request) ->
 #
 launch_popout = (request, sender) ->
   window = chrome.windows.create {
-    type: 'popup'
+    type: 'panel'
     url:  'popout.html'
     width: request.width
     height: request.height


### PR DESCRIPTION
Video window is opened as Chrome panel - attached to lower right part
of screen and on top of other windows. Panel can be detached from
position and moved around the screen, acting as Chrome popup window
(not being always on top). Panel window can be attached back to initial
position (always on top).
